### PR TITLE
Adding vtalisman to bench

### DIFF
--- a/benchmarks.js
+++ b/benchmarks.js
@@ -4,6 +4,7 @@ const { gen, sample, sampleOne } = require('testcheck'),
     Benchmark = require('benchmark'),
     leven = require('leven'),
     talisman = require('talisman/metrics/distance/levenshtein'),
+    vtalisman = talisman.limited,
     fast_levenshtein = require('fast-levenshtein').get,
     levenshtein_edit_distance = require('levenshtein-edit-distance'),
     js_levenshtein = require('js-levenshtein');
@@ -28,6 +29,7 @@ new Benchmark.Suite('',
     .add('symlar/veddist           ', harness((L, R, max_d) => veddist(L, R, LEVENSHTEIN, max_d)))
     .add('leven                    ', harness((L, R, max_d) => leven(L, R) <= max_d))
     .add('talisman                 ', harness((L, R, max_d) => talisman(L, R) <= max_d))
+    .add('vtalisman                ', harness((L, R, max_d) => vtalisman(max_d, L, R) <= max_d))
     .add('fast-levenshtein         ', harness((L, R, max_d) => fast_levenshtein(L, R) <= max_d))
     .add('js-levenshtein           ', harness((L, R, max_d) => js_levenshtein(L, R) <= max_d))
     .add('levenshtein-edit-distance', harness((L, R, max_d) => levenshtein_edit_distance(L, R) <= max_d))

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mocha": "^3.5.0",
     "mocha-clean": "^1.0.0",
     "mocha-testcheck": "^1.0.0-rc.0",
-    "talisman": "^0.19.1",
+    "talisman": "^0.20.0",
     "testcheck": "^1.0.0-rc.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
Hello @JoseLlarena. You are right to say that to "verify" levenshtein distance (or limited/clamped levenshtein distance) is magnitude faster than computing the whole distance (for case where the distance is high and strings not too long, obviously. I admit I forgot to document the limited version of talisman's lev distance. I therefore tried your benchmark and those are the results on my end:

```
 COMPUTATION VS VERIFICATION OF LEVENSHTEIN DISTANCE:

	symlar/lev                x 15.95 ops/sec ±1.99% (43 runs sampled)
	symlar/vlev               x 791 ops/sec ±1.63% (81 runs sampled)
	symlar/eddist             x 5.66 ops/sec ±3.27% (19 runs sampled)
	symlar/veddist            x 431 ops/sec ±1.45% (85 runs sampled)
	leven                     x 44.60 ops/sec ±1.52% (58 runs sampled)
	talisman                  x 53.49 ops/sec ±1.53% (69 runs sampled)
	vtalisman                 x 1,043 ops/sec ±1.40% (90 runs sampled)
	fast-levenshtein          x 21.56 ops/sec ±1.50% (40 runs sampled)
	js-levenshtein            x 80.05 ops/sec ±1.76% (68 runs sampled)
	levenshtein-edit-distance x 53.52 ops/sec ±1.88% (56 runs sampled)

	fastest is vtalisman
```

The edge vtalisman has is only due to improvements we made on both talisman and leven by really tuning honing the functions' code to their bare minimum.

---

On a totally different subject, I really like your phonetic levenshtein distance. Did you implement the Editex algorithm or did you create a whole new algorithm? You seem to use a combination of phonetic transliteration coupled with a mapping of phones' similarity to compute substitution weight? Is that it?